### PR TITLE
Add release archive and Windows installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,44 @@
 # Household Budgeting Desktop App
 
 This repository now ships a standalone desktop application for tracking a
-household budget. The app runs entirely on your machine, keeps all personal
-data inside a local `user_data/` folder, and provides tools to enter
-transactions, adjust your spending plan, and visualise progress against your
-budget.
+household budget while letting you build the interface with familiar
+[R Shiny](https://shiny.posit.co/) components. A small Python launcher embeds the
+Shiny app inside a native desktop window so you still get a double-clickable
+experience, but you can customise the UI and server logic directly in `r_app/`.
 
 ## Highlights
 
-- **Desktop-first experience** powered by [PySide6](https://doc.qt.io/qtforpython/) so
-you can launch the app like any other native program.
-- **Quick data entry** with form controls for date, description, category,
-payer, account, and amount alongside an editable table of every previous
-transaction.
+- **Desktop-first experience** powered by a lightweight PySide6 wrapper around a
+  Shiny application. Launch it like any other native program while developing in
+  R.
+- **Quick data entry** with Shiny inputs for dates, descriptions, categories,
+  payers, accounts, and amounts plus an editable table of every previous
+  transaction.
 - **Safe persistence** that keeps an on-disk CSV plus an automatically managed
-backup. You inspect a preview before every save so accidental overwrites are
-less likely.
+  backup. You inspect a preview before every save so accidental overwrites are
+  less likely.
 - **Budget planning tab** where you configure income sources and monthly targets
-per category. These feed directly into the reporting tools.
+  per category. These feed directly into the reporting tools.
 - **Interactive reports** to explore spending by category over any time window,
-monitor how close you are to each target, and list categories that are over or
-under budget.
+  monitor how close you are to each target, and list categories that are over or
+  under budget.
 - **Offline storage** – every CSV in `user_data/` is ignored by Git, keeping your
-finances private while remaining easy to back up or edit with another tool.
+  finances private while remaining easy to back up or edit with another tool.
 
 ## Prerequisites
 
-1. **Install Python 3.10 or newer.** The app uses modern typing features and
+1. **Install Python 3.10 or newer.** The wrapper uses modern typing features and
    PySide6 builds for current Python releases.
-2. **Create a virtual environment (recommended):**
+2. **Install R 4.2 or newer** and ensure the `Rscript` command is available on
+   your PATH. The first launch installs any required R packages automatically.
+3. **Create a virtual environment (recommended):**
 
    ```bash
    python -m venv .venv
-   source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+   source .venv/bin/activate  # Windows: .venv\Scripts\activate
    ```
 
-3. **Install the dependencies:**
+4. **Install the Python dependencies:**
 
    ```bash
    pip install -r requirements.txt
@@ -43,16 +46,20 @@ finances private while remaining easy to back up or edit with another tool.
 
 ## Running the app
 
-From the project root, launch the GUI with:
+From the project root, launch the desktop window with:
 
 ```bash
 python run_desktop.py
 ```
 
-The first run creates the `user_data/` directory and seeds it with example
-expenses, income sources, and category budgets that reflect a couple living on a
-roughly $90k/year household income. You can delete or edit those rows at any
-point; new empty files will be generated automatically if the CSVs are removed.
+The first run creates the `user_data/` directory, seeds it with example
+expenses, income sources, and category budgets, and installs the required R
+packages (Shiny, tidyverse components, DT, etc.) inside your local R
+environment. You can delete or edit those rows at any point; new empty files will
+be generated automatically if the CSVs are removed.
+
+If the Shiny process ever fails to boot you will see an error dialog. Consult
+`user_data/shiny_app.log` for the full R console output.
 
 ## Building a desktop installer / executable
 
@@ -74,10 +81,33 @@ You can bundle the application into a platform-specific executable using
    PyInstaller places the results in the `dist/` directory. On Windows you will
    find a `BudgetingTool` folder containing `BudgetingTool.exe`. On macOS and
    Linux you receive a similar bundled executable or launcher script depending on
-   the platform.
+   the platform. The bundle includes the Shiny sources from `r_app/`; you still
+   need R installed on the target machine so the wrapped process can run.
 
-3. (Optional) Create a desktop shortcut that points at the bundled executable so
-   you can launch the budgeting tool with a single click.
+   The script also zips the bundle into a timestamped archive such as
+   `BudgetingTool-windows-20240101.zip`. Upload that archive to your repository's
+   releases page and share a direct download link like:
+
+   ```
+   https://github.com/<your-account>/budgeting_tool/releases/latest/download/BudgetingTool-windows-20240101.zip
+   ```
+
+   Replace `<your-account>` and the archive name with the values that match your
+   release. Anyone with that URL can download the ready-to-run bundle without
+   cloning the repository.
+
+3. (Optional, Windows) Generate a traditional installer with a Start Menu entry
+   and an optional desktop shortcut using
+   [Inno Setup](https://jrsoftware.org/isinfo.php):
+
+   1. Install Inno Setup.
+   2. Run PyInstaller as shown above so `dist/BudgetingTool` exists.
+   3. Open `installer/windows_installer.iss` in Inno Setup and build it. The
+      script outputs `dist/BudgetingToolSetup.exe`.
+
+   During installation the user can tick **Create a desktop icon**. The installer
+   also adds a Start Menu shortcut and offers to launch the budgeting tool when
+   the wizard finishes.
 
 ## Application overview
 
@@ -111,6 +141,9 @@ refresh the reports.
 
 ## Customising the app
 
+- Edit `r_app/app.R` to adjust the UI, add new analysis panels, or integrate
+  other R packages. The Python wrapper simply launches whatever Shiny app lives
+  in that folder.
 - Add, rename, or remove categories directly in the Expenses or Budget tabs; the
   drop-downs update as soon as you save changes.
 - Replace the seeded data by deleting the CSV files inside `user_data/` while the
@@ -120,11 +153,12 @@ refresh the reports.
 
 ## Troubleshooting
 
-- If the GUI fails to launch, confirm that the Qt platform plugins are available
-  by reinstalling PySide6 (`pip install --force-reinstall PySide6`).
+- If the desktop window fails to launch, confirm that both Python and R are
+  installed and that `Rscript` is on your PATH.
 - When building with PyInstaller, ensure you run the command from an activated
-  virtual environment that already has PySide6, pandas, and matplotlib installed.
+  virtual environment that already has PySide6 and pandas installed, and that the
+  target machine also has R available.
 - To reset the app, close it and delete the `user_data/` folder. The next launch
   recreates it with the default sample records.
 
-Enjoy budgeting with a fully local desktop experience!
+Enjoy budgeting with a fully local desktop experience powered by R Shiny!

--- a/installer/build_installer.py
+++ b/installer/build_installer.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 import os
+import platform
+import shutil
 import subprocess
 import sys
+from datetime import datetime
 from pathlib import Path
 
 
@@ -25,10 +28,29 @@ def build() -> None:
         "BudgetingTool",
         "--add-data",
         f"{project_root / 'python_app'}{os.pathsep}python_app",
+        "--add-data",
+        f"{project_root / 'r_app'}{os.pathsep}r_app",
         str(project_root / "run_desktop.py"),
     ]
     print("Running", " ".join(cmd))
     subprocess.check_call(cmd, env=env)
+
+    dist_root = project_root / "dist"
+    bundle_dir = dist_root / "BudgetingTool"
+    if not bundle_dir.exists():
+        print("PyInstaller completed but the expected dist/BudgetingTool folder was not found.")
+        return
+
+    archive_suffix = platform.system().lower()
+    if archive_suffix == "darwin":
+        archive_suffix = "macos"
+    archive_name = f"BudgetingTool-{archive_suffix}"
+    timestamp = datetime.utcnow().strftime("%Y%m%d")
+    archive_path = dist_root / f"{archive_name}-{timestamp}"
+
+    print(f"Creating release archive {archive_path.name}.zip from {bundle_dir}…")
+    shutil.make_archive(str(archive_path), "zip", root_dir=bundle_dir)
+    print(f"Release archive ready: {archive_path.name}.zip")
 
 
 if __name__ == "__main__":

--- a/installer/windows_installer.iss
+++ b/installer/windows_installer.iss
@@ -1,0 +1,32 @@
+; Budgeting Tool Windows installer created with Inno Setup
+; Build this after running installer/build_installer.py so dist/BudgetingTool exists.
+
+[Setup]
+AppId={{C69163E5-2FA5-4F23-9A5E-8D9970A3B8D1}
+AppName=Budgeting Tool
+AppVersion=1.0.0
+AppPublisher=Budgeting Tool Team
+DefaultDirName={autopf}\Budgeting Tool
+DisableProgramGroupPage=yes
+OutputDir=dist
+OutputBaseFilename=BudgetingToolSetup
+Compression=lzma
+SolidCompression=yes
+ArchitecturesInstallIn64BitMode=x64
+WizardStyle=modern
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "dist\BudgetingTool\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs replacesameversion
+
+[Icons]
+Name: "{group}\Budgeting Tool"; Filename: "{app}\BudgetingTool.exe"
+Name: "{commondesktop}\Budgeting Tool"; Filename: "{app}\BudgetingTool.exe"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\BudgetingTool.exe"; Description: "{cm:LaunchProgram,Budgeting Tool}"; Flags: nowait postinstall skipifsilent

--- a/python_app/__init__.py
+++ b/python_app/__init__.py
@@ -1,4 +1,4 @@
-"""Python desktop budgeting application."""
+"""Python desktop wrapper for the R Shiny budgeting application."""
 
 from .main import main
 

--- a/python_app/main.py
+++ b/python_app/main.py
@@ -1,486 +1,102 @@
-"""Standalone budgeting desktop application entry point."""
+"""Launch the budgeting R Shiny application inside a desktop window."""
 from __future__ import annotations
 
 import sys
-from datetime import date
 from pathlib import Path
-from typing import Optional
 
-import pandas as pd
 from PySide6 import QtCore, QtGui, QtWidgets
-from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.figure import Figure
+from PySide6.QtCore import QUrl
+from PySide6.QtWebEngineWidgets import QWebEngineView
 
 from .data_store import BudgetDataStore
-from .models import PandasModel
+from .shiny_launcher import ShinyAppProcess
 
 
-class SavePreviewDialog(QtWidgets.QDialog):
-    """Modal dialog asking the user to confirm an expense save."""
+def _determine_data_dir(project_root: Path) -> Path:
+    """Return the directory used to persist user data."""
 
-    def __init__(self, frame: pd.DataFrame, parent: Optional[QtWidgets.QWidget] = None) -> None:
-        super().__init__(parent)
-        self.setWindowTitle("Confirm save")
-        self.setModal(True)
-        layout = QtWidgets.QVBoxLayout(self)
-
-        info_label = QtWidgets.QLabel(
-            "You are about to overwrite the expense log and its backup. "
-            "Review the most recent entries below before confirming."
-        )
-        info_label.setWordWrap(True)
-        layout.addWidget(info_label)
-
-        preview_table = QtWidgets.QTableWidget(self)
-        recent = frame.tail(15)
-        preview_table.setRowCount(len(recent.index))
-        preview_table.setColumnCount(len(recent.columns))
-        preview_table.setHorizontalHeaderLabels([col.title() for col in recent.columns])
-        for row_idx, (_, row) in enumerate(recent.iterrows()):
-            for col_idx, value in enumerate(row):
-                item = QtWidgets.QTableWidgetItem(str(value))
-                preview_table.setItem(row_idx, col_idx, item)
-        preview_table.resizeColumnsToContents()
-        layout.addWidget(preview_table)
-
-        button_box = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Save | QtWidgets.QDialogButtonBox.Cancel)
-        button_box.accepted.connect(self.accept)
-        button_box.rejected.connect(self.reject)
-        layout.addWidget(button_box)
+    if getattr(sys, "frozen", False):
+        executable_dir = Path(sys.executable).resolve().parent
+        return executable_dir / "user_data"
+    return project_root / "user_data"
 
 
-class ExpensesTab(QtWidgets.QWidget):
-    """Tab for entering and editing expenses."""
+class ShinyWindow(QtWidgets.QMainWindow):
+    """Qt window embedding the running R Shiny budgeting app."""
 
-    data_saved = QtCore.Signal(pd.DataFrame)
+    def __init__(self, shiny_process: ShinyAppProcess) -> None:
+        super().__init__()
+        self._shiny_process = shiny_process
 
-    def __init__(self, data_store: BudgetDataStore, parent: Optional[QtWidgets.QWidget] = None) -> None:
-        super().__init__(parent)
-        self.data_store = data_store
-        self.model = PandasModel(self.data_store.load_expenses())
-        self.model.frame_changed.connect(self._update_form_choices)
+        self.setWindowTitle("Household Budgeting (R Shiny)")
+        self.resize(1200, 800)
 
-        self._build_ui()
-        self._update_form_choices(self.model.to_dataframe())
-
-    def _build_ui(self) -> None:
-        layout = QtWidgets.QVBoxLayout(self)
-
-        form_box = QtWidgets.QGroupBox("Add a new expense")
-        form_layout = QtWidgets.QGridLayout(form_box)
-
-        self.date_input = QtWidgets.QDateEdit(self)
-        self.date_input.setCalendarPopup(True)
-        self.date_input.setDate(QtCore.QDate.currentDate())
-
-        self.description_input = QtWidgets.QLineEdit(self)
-
-        self.category_input = QtWidgets.QComboBox(self)
-        self.category_input.setEditable(True)
-
-        self.amount_input = QtWidgets.QDoubleSpinBox(self)
-        self.amount_input.setMaximum(1_000_000_000)
-        self.amount_input.setPrefix("$")
-        self.amount_input.setDecimals(2)
-
-        self.payer_input = QtWidgets.QComboBox(self)
-        self.payer_input.setEditable(True)
-
-        self.account_input = QtWidgets.QComboBox(self)
-        self.account_input.setEditable(True)
-
-        add_button = QtWidgets.QPushButton("Add expense")
-        add_button.clicked.connect(self._handle_add_expense)
-
-        form_layout.addWidget(QtWidgets.QLabel("Date"), 0, 0)
-        form_layout.addWidget(self.date_input, 0, 1)
-        form_layout.addWidget(QtWidgets.QLabel("Description"), 1, 0)
-        form_layout.addWidget(self.description_input, 1, 1)
-        form_layout.addWidget(QtWidgets.QLabel("Category"), 2, 0)
-        form_layout.addWidget(self.category_input, 2, 1)
-        form_layout.addWidget(QtWidgets.QLabel("Amount"), 3, 0)
-        form_layout.addWidget(self.amount_input, 3, 1)
-        form_layout.addWidget(QtWidgets.QLabel("Payer"), 4, 0)
-        form_layout.addWidget(self.payer_input, 4, 1)
-        form_layout.addWidget(QtWidgets.QLabel("Account"), 5, 0)
-        form_layout.addWidget(self.account_input, 5, 1)
-        form_layout.addWidget(add_button, 6, 0, 1, 2)
-
-        layout.addWidget(form_box)
-
-        self.table_view = QtWidgets.QTableView(self)
-        self.table_view.setModel(self.model)
-        self.table_view.horizontalHeader().setStretchLastSection(True)
-        self.table_view.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
-        self.table_view.setSelectionMode(QtWidgets.QTableView.SingleSelection)
-        layout.addWidget(self.table_view)
-
-        button_bar = QtWidgets.QHBoxLayout()
-        save_button = QtWidgets.QPushButton("Save changes")
-        save_button.clicked.connect(self._handle_save)
-        reload_button = QtWidgets.QPushButton("Reload from disk")
-        reload_button.clicked.connect(self._reload_from_disk)
-        remove_button = QtWidgets.QPushButton("Delete selected")
-        remove_button.clicked.connect(self._delete_selected)
-        button_bar.addWidget(save_button)
-        button_bar.addWidget(reload_button)
-        button_bar.addWidget(remove_button)
-        button_bar.addStretch()
-        layout.addLayout(button_bar)
-
-        help_label = QtWidgets.QLabel(
-            "Double-click cells to edit them. Saving will replace the backup after you confirm the preview."
-        )
-        help_label.setWordWrap(True)
-        layout.addWidget(help_label)
+        self._view = QWebEngineView(self)
+        self._view.loadFinished.connect(self._handle_load_finished)
+        self._view.setUrl(QUrl.fromUserInput(f"{shiny_process.url}/"))
+        self.setCentralWidget(self._view)
 
     # ------------------------------------------------------------------
-    def _handle_add_expense(self) -> None:
-        record = {
-            "date": self.date_input.date().toString("yyyy-MM-dd"),
-            "description": self.description_input.text().strip(),
-            "category": self.category_input.currentText().strip(),
-            "amount": round(self.amount_input.value(), 2),
-            "payer": self.payer_input.currentText().strip(),
-            "account": self.account_input.currentText().strip(),
-        }
-        self.model.append_record(record)
-        self.description_input.clear()
-        self.amount_input.setValue(0.0)
-        self.description_input.setFocus()
+    def _handle_load_finished(self, ok: bool) -> None:
+        """Surface connection failures from the embedded web view."""
 
-    def _handle_save(self) -> None:
-        frame = self.model.to_dataframe()
-        dialog = SavePreviewDialog(frame, self)
-        if dialog.exec() == QtWidgets.QDialog.Accepted:
-            self.data_store.save_expenses(frame)
-            QtWidgets.QMessageBox.information(
-                self,
-                "Expenses saved",
-                "The expense log and backup were updated successfully.",
-            )
-            self.data_saved.emit(frame)
-
-    def _reload_from_disk(self) -> None:
-        frame = self.data_store.load_expenses()
-        self.model.update_frame(frame)
-
-    def _delete_selected(self) -> None:
-        selection = self.table_view.selectionModel().selectedRows()
-        if not selection:
+        if ok:
             return
-        index = selection[0]
-        self.model.removeRows(index.row(), 1)
 
-    def _update_form_choices(self, frame: pd.DataFrame) -> None:
-        def sync_combo(combo: QtWidgets.QComboBox, values: pd.Series) -> None:
-            existing = {combo.itemText(i) for i in range(combo.count())}
-            for value in sorted({str(v) for v in values if str(v).strip()}):
-                if value not in existing:
-                    combo.addItem(value)
-
-        if "category" in frame.columns:
-            sync_combo(self.category_input, frame["category"].dropna())
-        budget_categories = self.data_store.load_category_budget()
-        if not budget_categories.empty and "category" in budget_categories.columns:
-            sync_combo(self.category_input, budget_categories["category"].dropna())
-        if "payer" in frame.columns:
-            sync_combo(self.payer_input, frame["payer"].dropna())
-        if "account" in frame.columns:
-            sync_combo(self.account_input, frame["account"].dropna())
-
-
-class BudgetTab(QtWidgets.QWidget):
-    """Tab for configuring income sources and budget targets."""
-
-    data_saved = QtCore.Signal()
-
-    def __init__(self, data_store: BudgetDataStore, parent: Optional[QtWidgets.QWidget] = None) -> None:
-        super().__init__(parent)
-        self.data_store = data_store
-        self.income_model = PandasModel(self.data_store.load_income_sources())
-        self.budget_model = PandasModel(self.data_store.load_category_budget())
-
-        self._build_ui()
-
-    def _build_ui(self) -> None:
-        layout = QtWidgets.QVBoxLayout(self)
-
-        income_box = QtWidgets.QGroupBox("Monthly income sources")
-        income_layout = QtWidgets.QVBoxLayout(income_box)
-        self.income_table = QtWidgets.QTableView(self)
-        self.income_table.setModel(self.income_model)
-        self.income_table.horizontalHeader().setStretchLastSection(True)
-        income_layout.addWidget(self.income_table)
-
-        income_buttons = QtWidgets.QHBoxLayout()
-        add_income = QtWidgets.QPushButton("Add income source")
-        add_income.clicked.connect(lambda: self._add_row(self.income_model))
-        remove_income = QtWidgets.QPushButton("Delete selected")
-        remove_income.clicked.connect(lambda: self._remove_selected(self.income_table, self.income_model))
-        save_income = QtWidgets.QPushButton("Save income")
-        save_income.clicked.connect(self._save_income_sources)
-        income_buttons.addWidget(add_income)
-        income_buttons.addWidget(remove_income)
-        income_buttons.addWidget(save_income)
-        income_buttons.addStretch()
-        income_layout.addLayout(income_buttons)
-
-        layout.addWidget(income_box)
-
-        budget_box = QtWidgets.QGroupBox("Monthly category targets")
-        budget_layout = QtWidgets.QVBoxLayout(budget_box)
-        self.budget_table = QtWidgets.QTableView(self)
-        self.budget_table.setModel(self.budget_model)
-        self.budget_table.horizontalHeader().setStretchLastSection(True)
-        budget_layout.addWidget(self.budget_table)
-
-        budget_buttons = QtWidgets.QHBoxLayout()
-        add_budget = QtWidgets.QPushButton("Add category")
-        add_budget.clicked.connect(lambda: self._add_row(self.budget_model))
-        remove_budget = QtWidgets.QPushButton("Delete selected")
-        remove_budget.clicked.connect(lambda: self._remove_selected(self.budget_table, self.budget_model))
-        save_budget = QtWidgets.QPushButton("Save targets")
-        save_budget.clicked.connect(self._save_budget)
-        budget_buttons.addWidget(add_budget)
-        budget_buttons.addWidget(remove_budget)
-        budget_buttons.addWidget(save_budget)
-        budget_buttons.addStretch()
-        budget_layout.addLayout(budget_buttons)
-
-        layout.addWidget(budget_box)
-
-        help_label = QtWidgets.QLabel(
-            "Use these tables to define the plan for the month. "
-            "The reports tab compares actual spending against your targets."
+        QtWidgets.QMessageBox.warning(
+            self,
+            "Unable to display budgeting app",
+            (
+                "The embedded browser could not load the Shiny interface.\n"
+                "Check 'user_data/shiny_app.log' for errors and ensure R is installed."
+            ),
         )
-        help_label.setWordWrap(True)
-        layout.addWidget(help_label)
-
-    def _add_row(self, model: PandasModel) -> None:
-        empty = {}
-        for name in model.column_names():
-            empty[name] = 0.0 if "amount" in name else ""
-        model.append_record(empty)
-
-    def _remove_selected(self, view: QtWidgets.QTableView, model: PandasModel) -> None:
-        selection = view.selectionModel().selectedRows()
-        if not selection:
-            return
-        model.removeRows(selection[0].row(), 1)
-
-    def _save_income_sources(self) -> None:
-        frame = self.income_model.to_dataframe()
-        self.data_store.save_income_sources(frame)
-        QtWidgets.QMessageBox.information(self, "Income saved", "Income sources updated.")
-        self.data_saved.emit()
-
-    def _save_budget(self) -> None:
-        frame = self.budget_model.to_dataframe()
-        self.data_store.save_category_budget(frame)
-        QtWidgets.QMessageBox.information(self, "Targets saved", "Category targets updated.")
-        self.data_saved.emit()
-
-
-class ReportsTab(QtWidgets.QWidget):
-    """Tab that visualises spending versus the plan."""
-
-    def __init__(self, data_store: BudgetDataStore, parent: Optional[QtWidgets.QWidget] = None) -> None:
-        super().__init__(parent)
-        self.data_store = data_store
-
-        self._build_ui()
-        self._set_default_dates()
-        self.refresh_report()
-
-    def _build_ui(self) -> None:
-        layout = QtWidgets.QVBoxLayout(self)
-
-        controls = QtWidgets.QHBoxLayout()
-        controls.addWidget(QtWidgets.QLabel("Start date"))
-        self.start_date = QtWidgets.QDateEdit(self)
-        self.start_date.setCalendarPopup(True)
-        controls.addWidget(self.start_date)
-        controls.addWidget(QtWidgets.QLabel("End date"))
-        self.end_date = QtWidgets.QDateEdit(self)
-        self.end_date.setCalendarPopup(True)
-        controls.addWidget(self.end_date)
-        refresh_btn = QtWidgets.QPushButton("Refresh")
-        refresh_btn.clicked.connect(self.refresh_report)
-        controls.addWidget(refresh_btn)
-        controls.addStretch()
-        layout.addLayout(controls)
-
-        self.summary_table = QtWidgets.QTableWidget(self)
-        layout.addWidget(self.summary_table)
-
-        split_layout = QtWidgets.QHBoxLayout()
-        self.over_list = QtWidgets.QListWidget(self)
-        self.over_list.setSelectionMode(QtWidgets.QAbstractItemView.NoSelection)
-        self.over_list.setMaximumWidth(250)
-        self.over_list.setMinimumWidth(200)
-        split_layout.addWidget(_with_label("Over budget", self.over_list))
-
-        self.under_list = QtWidgets.QListWidget(self)
-        self.under_list.setSelectionMode(QtWidgets.QAbstractItemView.NoSelection)
-        self.under_list.setMaximumWidth(250)
-        self.under_list.setMinimumWidth(200)
-        split_layout.addWidget(_with_label("Under budget", self.under_list))
-
-        self.figure = Figure(figsize=(6, 4))
-        self.canvas = FigureCanvas(self.figure)
-        split_layout.addWidget(self.canvas, stretch=1)
-
-        layout.addLayout(split_layout)
-
-        self.income_label = QtWidgets.QLabel("Total planned income: $0.00")
-        layout.addWidget(self.income_label)
-
-    def _set_default_dates(self) -> None:
-        end = QtCore.QDate.currentDate()
-        start = end.addDays(-30)
-        self.start_date.setDate(start)
-        self.end_date.setDate(end)
 
     # ------------------------------------------------------------------
-    def refresh_report(self) -> None:
-        expenses = self.data_store.load_expenses()
-        budgets = self.data_store.load_category_budget()
-        income = self.data_store.load_income_sources()
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:  # type: ignore[override]
+        """Ensure the R process stops when the window closes."""
 
-        if expenses.empty:
-            self.summary_table.clear()
-            self.summary_table.setRowCount(0)
-            self.summary_table.setColumnCount(0)
-            self.over_list.clear()
-            self.under_list.clear()
-            self.figure.clear()
-            self.canvas.draw()
-            self.income_label.setText("No expenses recorded yet.")
-            return
-
-        start = _qdate_to_date(self.start_date.date())
-        end = _qdate_to_date(self.end_date.date())
-        expenses["date"] = pd.to_datetime(expenses["date"])
-        mask = (expenses["date"].dt.date >= start) & (expenses["date"].dt.date <= end)
-        filtered = expenses.loc[mask]
-        if filtered.empty:
-            summary = pd.DataFrame(columns=["category", "amount"])
-        else:
-            summary = (
-                filtered.groupby("category", as_index=False)["amount"].sum().sort_values(
-                    "amount", ascending=False
-                )
-            )
-
-        merged = budgets.copy()
-        merged = merged.rename(columns={"target_amount": "target"})
-        merged = merged.merge(summary, on="category", how="outer")
-        merged["target"] = merged["target"].fillna(0.0)
-        merged["amount"] = merged["amount"].fillna(0.0)
-        merged["difference"] = merged["target"] - merged["amount"]
-        merged["progress_pct"] = merged.apply(
-            lambda row: 0.0 if row["target"] == 0 else (row["amount"] / row["target"]) * 100,
-            axis=1,
-        )
-        merged = merged.sort_values("amount", ascending=False)
-
-        headers = ["Category", "Spent", "Target", "Remaining", "% of target"]
-        self.summary_table.setRowCount(len(merged.index))
-        self.summary_table.setColumnCount(len(headers))
-        self.summary_table.setHorizontalHeaderLabels(headers)
-        for row_idx, (_, row) in enumerate(merged.iterrows()):
-            values = [
-                row["category"],
-                f"${row['amount']:.2f}",
-                f"${row['target']:.2f}",
-                f"${row['difference']:.2f}",
-                f"{row['progress_pct']:.1f}%",
-            ]
-            for col_idx, value in enumerate(values):
-                item = QtWidgets.QTableWidgetItem(value)
-                if col_idx > 0:
-                    item.setTextAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
-                self.summary_table.setItem(row_idx, col_idx, item)
-        self.summary_table.resizeColumnsToContents()
-
-        over_budget = merged[merged["difference"] < 0]
-        under_budget = merged[merged["difference"] > 0]
-        self.over_list.clear()
-        for _, row in over_budget.sort_values("difference").iterrows():
-            self.over_list.addItem(f"{row['category']}: over by ${abs(row['difference']):.2f}")
-        self.under_list.clear()
-        for _, row in under_budget.sort_values("difference", ascending=False).iterrows():
-            self.under_list.addItem(f"{row['category']}: ${row['difference']:.2f} remaining")
-
-        self.figure.clear()
-        axis = self.figure.add_subplot(111)
-        axis.set_title("Spending by category")
-        if not summary.empty:
-            axis.bar(summary["category"], summary["amount"], color="#2E86AB")
-            axis.set_ylabel("Amount ($)")
-            axis.tick_params(axis="x", rotation=45, ha="right")
-        else:
-            axis.text(0.5, 0.5, "No expenses in range", ha="center", va="center")
-        self.figure.tight_layout()
-        self.canvas.draw()
-
-        total_income = income["amount"].sum() if not income.empty else 0.0
-        total_spent = merged["amount"].sum()
-        self.income_label.setText(
-            f"Total planned income: ${total_income:.2f} — Spending in range: ${total_spent:.2f}"
-        )
+        try:
+            self._shiny_process.stop()
+        finally:
+            super().closeEvent(event)
 
 
-class MainWindow(QtWidgets.QMainWindow):
-    def __init__(self, data_store: BudgetDataStore, parent: Optional[QtWidgets.QWidget] = None) -> None:
-        super().__init__(parent)
-        self.setWindowTitle("Household Budgeting Tool")
-        self.resize(1100, 700)
+def main() -> int:
+    """Entry point executed by ``run_desktop.py`` and PyInstaller."""
 
-        tabs = QtWidgets.QTabWidget(self)
-        self.expenses_tab = ExpensesTab(data_store, self)
-        self.budget_tab = BudgetTab(data_store, self)
-        self.reports_tab = ReportsTab(data_store, self)
+    project_root = Path(__file__).resolve().parents[1]
+    data_dir = _determine_data_dir(project_root)
 
-        tabs.addTab(self.expenses_tab, "Expenses")
-        tabs.addTab(self.budget_tab, "Budget planning")
-        tabs.addTab(self.reports_tab, "Reports")
-        self.setCentralWidget(tabs)
+    # Prepare the data directory and seed files before the R app boots.
+    BudgetDataStore(base_dir=data_dir)
 
-        self.expenses_tab.data_saved.connect(lambda _: self.reports_tab.refresh_report())
-        self.budget_tab.data_saved.connect(self.reports_tab.refresh_report)
-        self.budget_tab.data_saved.connect(
-            lambda: self.expenses_tab._update_form_choices(self.expenses_tab.model.to_dataframe())
-        )
-
-
-def _with_label(title: str, widget: QtWidgets.QWidget) -> QtWidgets.QWidget:
-    container = QtWidgets.QWidget()
-    layout = QtWidgets.QVBoxLayout(container)
-    label = QtWidgets.QLabel(title)
-    label.setAlignment(QtCore.Qt.AlignHCenter)
-    layout.addWidget(label)
-    layout.addWidget(widget)
-    return container
-
-
-def _qdate_to_date(value: QtCore.QDate) -> date:
-    if hasattr(value, "toPython"):
-        return value.toPython()
-    return value.toPyDate()
-
-
-def main() -> None:
-    base_dir = Path.cwd()
-    data_store = BudgetDataStore(base_dir / "user_data")
-
+    QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_ShareOpenGLContexts, True)
     app = QtWidgets.QApplication(sys.argv)
-    app.setWindowIcon(QtGui.QIcon.fromTheme("document-edit"))
-    window = MainWindow(data_store)
+
+    shiny_process: ShinyAppProcess | None = None
+
+    try:
+        shiny_process = ShinyAppProcess(project_root, data_dir=data_dir)
+        shiny_process.start()
+        shiny_process.wait_until_ready()
+    except Exception as exc:  # pragma: no cover - GUI error dialog
+        QtWidgets.QMessageBox.critical(
+            None,
+            "Failed to start budgeting app",
+            f"{exc}\n\nCheck 'user_data/shiny_app.log' for detailed logs.",
+        )
+        if shiny_process is not None:
+            shiny_process.stop()
+        return 1
+
+    window = ShinyWindow(shiny_process)
     window.show()
-    sys.exit(app.exec())
+
+    exit_code = app.exec()
+    shiny_process.stop()
+    return int(exit_code)
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/python_app/shiny_launcher.py
+++ b/python_app/shiny_launcher.py
@@ -1,0 +1,135 @@
+"""Utilities for booting and monitoring the bundled R Shiny app."""
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional, TextIO
+from urllib import error, request
+
+
+class ShinyAppProcess:
+    """Launch and manage the lifetime of the R Shiny budgeting application."""
+
+    def __init__(
+        self,
+        project_root: Path,
+        port: Optional[int] = None,
+        data_dir: Optional[Path] = None,
+    ) -> None:
+        self.project_root = project_root
+        self.port = port or self._find_free_port()
+        self.url = f"http://127.0.0.1:{self.port}"
+        self.data_dir = Path(data_dir) if data_dir is not None else project_root / "user_data"
+
+        self._process: subprocess.Popen[str] | None = None
+        self._log_handle: Optional[TextIO] = None
+
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Start the R Shiny process in the background."""
+
+        rscript = self._find_rscript()
+        launch_script = self.project_root / "r_app" / "launch_shiny.R"
+        if not launch_script.exists():
+            raise RuntimeError(
+                "The R launcher script is missing. Expected to find 'r_app/launch_shiny.R'."
+            )
+
+        data_dir = self.data_dir
+        data_dir.mkdir(parents=True, exist_ok=True)
+        log_path = data_dir / "shiny_app.log"
+        self._log_handle = log_path.open("w", encoding="utf-8")
+
+        env = os.environ.copy()
+        env["R_SHINY_BUDGET_DATA_DIR"] = str(data_dir)
+        env["R_SHINY_APP_ROOT"] = str(self.project_root / "r_app")
+
+        args = [rscript, str(launch_script), str(self.port), str(data_dir)]
+        try:
+            self._process = subprocess.Popen(
+                args,
+                cwd=str(self.project_root / "r_app"),
+                stdout=self._log_handle,
+                stderr=subprocess.STDOUT,
+                env=env,
+                text=True,
+            )
+        except Exception:
+            if self._log_handle is not None:
+                self._log_handle.close()
+                self._log_handle = None
+            raise
+
+    # ------------------------------------------------------------------
+    def wait_until_ready(self, timeout: float = 60.0) -> None:
+        """Block until the Shiny app responds to HTTP requests."""
+
+        if self._process is None:
+            raise RuntimeError("Shiny process was not started.")
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self._process.poll() is not None:
+                raise RuntimeError(
+                    "The R Shiny process exited before it became ready."
+                )
+
+            try:
+                with request.urlopen(self.url, timeout=1):
+                    return
+            except error.URLError:
+                time.sleep(0.5)
+
+        raise TimeoutError(
+            "Timed out waiting for the R Shiny app to start. "
+            "Review 'user_data/shiny_app.log' for details."
+        )
+
+    # ------------------------------------------------------------------
+    def stop(self) -> None:
+        """Terminate the Shiny process if it is still running."""
+
+        if self._process is None:
+            if self._log_handle is not None:
+                self._log_handle.close()
+                self._log_handle = None
+            return
+
+        if self._process.poll() is None:
+            try:
+                if os.name == "nt":
+                    self._process.terminate()
+                else:
+                    self._process.send_signal(signal.SIGINT)
+                self._process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+        self._process = None
+
+        if self._log_handle is not None:
+            self._log_handle.close()
+            self._log_handle = None
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _find_free_port() -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            return int(sock.getsockname()[1])
+
+    @staticmethod
+    def _find_rscript() -> str:
+        candidate = shutil.which("Rscript")
+        if candidate is None:
+            raise RuntimeError(
+                "Unable to locate the 'Rscript' executable. Install R and ensure it is on your PATH."
+            )
+        return candidate
+
+
+__all__ = ["ShinyAppProcess"]

--- a/r_app/app.R
+++ b/r_app/app.R
@@ -1,0 +1,588 @@
+library(shiny)
+library(shinythemes)
+library(DT)
+library(readr)
+library(dplyr)
+library(tidyr)
+library(lubridate)
+library(ggplot2)
+library(scales)
+
+# -----------------------------------------------------------------------------
+# File helpers ---------------------------------------------------------------
+resolve_data_dir <- function() {
+  env_dir <- Sys.getenv("R_SHINY_BUDGET_DATA_DIR", unset = NA_character_)
+  if (!is.na(env_dir) && nzchar(env_dir)) {
+    return(normalizePath(env_dir, mustWork = FALSE))
+  }
+  default_dir <- file.path(normalizePath("..", winslash = "/", mustWork = FALSE), "user_data")
+  normalizePath(default_dir, winslash = "/", mustWork = FALSE)
+}
+
+data_dir <- resolve_data_dir()
+if (!dir.exists(data_dir)) {
+  dir.create(data_dir, recursive = TRUE, showWarnings = FALSE)
+}
+message("Using budgeting data directory: ", data_dir)
+
+paths <- list(
+  expenses = file.path(data_dir, "expenses.csv"),
+  expenses_backup = file.path(data_dir, "expenses_backup.csv"),
+  income = file.path(data_dir, "income_sources.csv"),
+  budget = file.path(data_dir, "category_budget.csv")
+)
+
+empty_expenses <- tibble(
+  date = character(),
+  description = character(),
+  category = character(),
+  amount = double(),
+  payer = character(),
+  account = character()
+)
+
+empty_income <- tibble(source = character(), amount = double())
+empty_budget <- tibble(category = character(), target_amount = double())
+
+safe_read <- function(path, col_types, empty_frame, transform) {
+  if (!file.exists(path)) {
+    return(empty_frame)
+  }
+  tryCatch(
+    {
+      df <- readr::read_csv(
+        path,
+        col_types = col_types,
+        show_col_types = FALSE,
+        progress = FALSE
+      )
+      transform(df)
+    },
+    error = function(err) {
+      warning(sprintf("Failed to read %s: %s", basename(path), conditionMessage(err)))
+      empty_frame
+    }
+  )
+}
+
+prepare_expenses <- function(df) {
+  df <- df %>%
+    mutate(
+      date = as_date(ymd(date, quiet = TRUE)),
+      date = if_else(is.na(date), today(), date),
+      date = format(date, "%Y-%m-%d"),
+      description = replace_na(trimws(as.character(description)), ""),
+      category = replace_na(trimws(as.character(category)), ""),
+      payer = replace_na(trimws(as.character(payer)), ""),
+      account = replace_na(trimws(as.character(account)), ""),
+      amount = replace_na(as.numeric(amount), 0)
+    )
+  for (col in names(empty_expenses)) {
+    if (!col %in% names(df)) {
+      df[[col]] <- empty_expenses[[col]]
+    }
+  }
+  df %>% select(all_of(names(empty_expenses)))
+}
+
+prepare_numeric_frame <- function(df, name_col, amount_col) {
+  df <- df %>%
+    mutate(
+      !!name_col := replace_na(trimws(as.character(.data[[name_col]])), ""),
+      !!amount_col := replace_na(as.numeric(.data[[amount_col]]), 0)
+    )
+  for (col in c(name_col, amount_col)) {
+    if (!col %in% names(df)) {
+      df[[col]] <- if (col == amount_col) 0 else ""
+    }
+  }
+  df %>% select(all_of(c(name_col, amount_col)))
+}
+
+read_expenses <- function() {
+  safe_read(
+    paths$expenses,
+    col_types = cols(
+      date = col_character(),
+      description = col_character(),
+      category = col_character(),
+      amount = col_double(),
+      payer = col_character(),
+      account = col_character(),
+      .default = col_guess()
+    ),
+    empty_expenses,
+    function(df) {
+      df %>%
+        bind_rows(empty_expenses) %>%
+        select(all_of(names(empty_expenses))) %>%
+        prepare_expenses()
+    }
+  )
+}
+
+read_income <- function() {
+  safe_read(
+    paths$income,
+    col_types = cols(
+      source = col_character(),
+      amount = col_double(),
+      .default = col_guess()
+    ),
+    empty_income,
+    function(df) {
+      df %>%
+        bind_rows(empty_income) %>%
+        select(all_of(names(empty_income))) %>%
+        prepare_numeric_frame("source", "amount")
+    }
+  )
+}
+
+read_budget <- function() {
+  safe_read(
+    paths$budget,
+    col_types = cols(
+      category = col_character(),
+      target_amount = col_double(),
+      .default = col_guess()
+    ),
+    empty_budget,
+    function(df) {
+      df %>%
+        bind_rows(empty_budget) %>%
+        select(all_of(names(empty_budget))) %>%
+        prepare_numeric_frame("category", "target_amount")
+    }
+  )
+}
+
+write_expenses <- function(df) {
+  df <- prepare_expenses(df)
+  if (file.exists(paths$expenses)) {
+    file.copy(paths$expenses, paths$expenses_backup, overwrite = TRUE)
+  }
+  readr::write_csv(df, paths$expenses, progress = FALSE)
+}
+
+write_income <- function(df) {
+  df <- prepare_numeric_frame(df, "source", "amount")
+  readr::write_csv(df, paths$income, progress = FALSE)
+}
+
+write_budget <- function(df) {
+  df <- prepare_numeric_frame(df, "category", "target_amount")
+  readr::write_csv(df, paths$budget, progress = FALSE)
+}
+
+clean_choices <- function(values) {
+  values <- values[!is.na(values) & nzchar(values)]
+  sort(unique(values))
+}
+
+category_summary <- function(expenses, budgets) {
+  if (!nrow(expenses)) {
+    return(tibble(category = character(), spent = double(), target_amount = double(), difference = double()))
+  }
+  summary <- expenses %>%
+    mutate(date = ymd(date, quiet = TRUE)) %>%
+    filter(!is.na(date)) %>%
+    group_by(category) %>%
+    summarise(spent = sum(amount, na.rm = TRUE), .groups = "drop") %>%
+    full_join(budgets, by = "category") %>%
+    mutate(
+      target_amount = replace_na(target_amount, 0),
+      spent = replace_na(spent, 0),
+      difference = spent - target_amount
+    ) %>%
+    arrange(desc(spent))
+  summary
+}
+
+# -----------------------------------------------------------------------------
+# UI -------------------------------------------------------------------------
+ui <- navbarPage(
+  title = "Household Budgeting",
+  theme = shinytheme("flatly"),
+  tabPanel(
+    "Expenses",
+    fluidRow(
+      column(
+        width = 4,
+        h3("Add a new expense"),
+        dateInput("expense_date", "Date", value = Sys.Date()),
+        textInput("expense_description", "Description"),
+        selectizeInput(
+          "expense_category",
+          "Category",
+          choices = NULL,
+          options = list(create = TRUE, persist = TRUE)
+        ),
+        numericInput("expense_amount", "Amount", value = 0, min = 0, step = 0.01),
+        selectizeInput(
+          "expense_payer",
+          "Payer",
+          choices = NULL,
+          options = list(create = TRUE, persist = TRUE)
+        ),
+        selectizeInput(
+          "expense_account",
+          "Account",
+          choices = NULL,
+          options = list(create = TRUE, persist = TRUE)
+        ),
+        actionButton("add_expense", "Add expense", class = "btn-primary")
+      ),
+      column(
+        width = 8,
+        h3("Logged expenses"),
+        p("Double-click a cell to edit it directly. Select a row to delete it."),
+        DTOutput("expenses_table"),
+        br(),
+        actionButton("delete_expense", "Delete selected"),
+        actionButton("reload_expenses", "Reload from disk"),
+        actionButton("save_expenses", "Save changes", class = "btn-success")
+      )
+    )
+  ),
+  tabPanel(
+    "Budget planning",
+    fluidRow(
+      column(
+        width = 6,
+        h3("Income sources"),
+        p("Add each recurring monthly income stream."),
+        actionButton("add_income", "Add income row"),
+        actionButton("delete_income", "Delete selected"),
+        actionButton("save_income", "Save income", class = "btn-success"),
+        DTOutput("income_table")
+      ),
+      column(
+        width = 6,
+        h3("Category targets"),
+        p("Set monthly targets for each spending category."),
+        actionButton("add_budget", "Add budget row"),
+        actionButton("delete_budget", "Delete selected"),
+        actionButton("save_budget", "Save targets", class = "btn-success"),
+        DTOutput("budget_table")
+      )
+    )
+  ),
+  tabPanel(
+    "Reports",
+    fluidRow(
+      column(
+        width = 4,
+        dateRangeInput(
+          "report_dates",
+          "Date range",
+          start = Sys.Date() - 29,
+          end = Sys.Date(),
+          max = Sys.Date()
+        ),
+        verbatimTextOutput("report_summary")
+      ),
+      column(
+        width = 8,
+        plotOutput("spending_plot", height = 320)
+      )
+    ),
+    fluidRow(
+      column(
+        width = 12,
+        h4("Category overview"),
+        DTOutput("category_table")
+      )
+    ),
+    fluidRow(
+      column(
+        width = 6,
+        h4("Over budget"),
+        DTOutput("over_budget_table")
+      ),
+      column(
+        width = 6,
+        h4("Under budget"),
+        DTOutput("under_budget_table")
+      )
+    )
+  )
+)
+
+# -----------------------------------------------------------------------------
+# Server ---------------------------------------------------------------------
+server <- function(input, output, session) {
+  expenses <- reactiveVal(read_expenses())
+  income <- reactiveVal(read_income())
+  budgets <- reactiveVal(read_budget())
+
+  observe({
+    cats <- clean_choices(c(expenses()[["category"]], budgets()[["category"]]))
+    updateSelectizeInput(session, "expense_category", choices = cats, server = TRUE)
+
+    payers <- clean_choices(expenses()[["payer"]])
+    updateSelectizeInput(session, "expense_payer", choices = payers, server = TRUE)
+
+    accounts <- clean_choices(expenses()[["account"]])
+    updateSelectizeInput(session, "expense_account", choices = accounts, server = TRUE)
+  })
+
+  observeEvent(input$add_expense, {
+    amount_value <- input$expense_amount
+    if (is.null(amount_value) || is.na(amount_value)) {
+      amount_value <- 0
+    }
+    new_row <- tibble(
+      date = as.character(input$expense_date),
+      description = trimws(input$expense_description),
+      category = trimws(input$expense_category),
+      amount = round(as.numeric(amount_value), 2),
+      payer = trimws(input$expense_payer),
+      account = trimws(input$expense_account)
+    )
+    updated <- bind_rows(expenses(), new_row) %>% prepare_expenses()
+    expenses(updated)
+
+    updateTextInput(session, "expense_description", value = "")
+    updateNumericInput(session, "expense_amount", value = 0)
+  })
+
+  observeEvent(input$delete_expense, {
+    selected <- input$expenses_table_rows_selected
+    if (length(selected)) {
+      df <- expenses()
+      df <- df[-selected, , drop = FALSE]
+      expenses(df)
+    }
+  })
+
+  observeEvent(input$reload_expenses, {
+    expenses(read_expenses())
+  })
+
+  observeEvent(input$expenses_table_cell_edit, {
+    info <- input$expenses_table_cell_edit
+    df <- expenses()
+    row <- info$row
+    col <- info$col + 1
+    col_name <- names(df)[col]
+    value <- info$value
+
+    if (col_name == "amount") {
+      value <- as.numeric(value)
+      if (is.na(value)) value <- 0
+    } else {
+      value <- trimws(as.character(value))
+    }
+    df[row, col_name] <- value
+    expenses(prepare_expenses(df))
+  })
+
+  observeEvent(input$save_expenses, {
+    df <- expenses()
+    if (!nrow(df)) {
+      showNotification("There are no expenses to save yet.", type = "warning")
+      return()
+    }
+    preview <- tail(df, 15)
+    output$save_preview <- renderDT({
+      DT::datatable(
+        preview,
+        options = list(pageLength = min(nrow(preview), 5), dom = "tip"),
+        rownames = FALSE
+      ) %>%
+        formatCurrency("amount", currency = "$", interval = 3, mark = ",")
+    })
+    showModal(
+      modalDialog(
+        title = "Confirm expense save",
+        size = "l",
+        easyClose = FALSE,
+        footer = tagList(
+          modalButton("Cancel"),
+          actionButton("confirm_save_expenses", "Save", class = "btn-primary")
+        ),
+        p("Review the most recent entries. Saving will also update the backup copy."),
+        DTOutput("save_preview")
+      )
+    )
+  })
+
+  observeEvent(input$confirm_save_expenses, {
+    write_expenses(expenses())
+    expenses(read_expenses())
+    removeModal()
+    showNotification("Expenses saved", type = "message")
+  })
+
+  output$expenses_table <- renderDT({
+    DT::datatable(
+      expenses(),
+      selection = "single",
+      editable = "cell",
+      rownames = FALSE,
+      options = list(pageLength = 10, scrollX = TRUE)
+    ) %>%
+      formatCurrency("amount", currency = "$", interval = 3, mark = ",")
+  })
+
+  # Income management --------------------------------------------------------
+  observeEvent(input$add_income, {
+    income(bind_rows(income(), tibble(source = "", amount = 0)))
+  })
+
+  observeEvent(input$delete_income, {
+    rows <- input$income_table_rows_selected
+    if (length(rows)) {
+      df <- income()
+      df <- df[-rows, , drop = FALSE]
+      income(df)
+    }
+  })
+
+  observeEvent(input$income_table_cell_edit, {
+    info <- input$income_table_cell_edit
+    df <- income()
+    col <- names(df)[info$col + 1]
+    value <- if (col == "amount") as.numeric(info$value) else trimws(as.character(info$value))
+    if (col == "amount" && is.na(value)) value <- 0
+    df[info$row, col] <- value
+    income(prepare_numeric_frame(df, "source", "amount"))
+  })
+
+  observeEvent(input$save_income, {
+    cleaned <- prepare_numeric_frame(income(), "source", "amount")
+    write_income(cleaned)
+    income(cleaned)
+    showNotification("Income saved", type = "message")
+  })
+
+  output$income_table <- renderDT({
+    DT::datatable(
+      income(),
+      selection = "single",
+      editable = "cell",
+      rownames = FALSE,
+      options = list(dom = "t", pageLength = 8)
+    ) %>%
+      formatCurrency("amount", currency = "$", interval = 3, mark = ",")
+  })
+
+  # Budget management --------------------------------------------------------
+  observeEvent(input$add_budget, {
+    budgets(bind_rows(budgets(), tibble(category = "", target_amount = 0)))
+  })
+
+  observeEvent(input$delete_budget, {
+    rows <- input$budget_table_rows_selected
+    if (length(rows)) {
+      df <- budgets()
+      df <- df[-rows, , drop = FALSE]
+      budgets(df)
+    }
+  })
+
+  observeEvent(input$budget_table_cell_edit, {
+    info <- input$budget_table_cell_edit
+    df <- budgets()
+    col <- names(df)[info$col + 1]
+    value <- if (col == "target_amount") as.numeric(info$value) else trimws(as.character(info$value))
+    if (col == "target_amount" && is.na(value)) value <- 0
+    df[info$row, col] <- value
+    budgets(prepare_numeric_frame(df, "category", "target_amount"))
+  })
+
+  observeEvent(input$save_budget, {
+    cleaned <- prepare_numeric_frame(budgets(), "category", "target_amount")
+    write_budget(cleaned)
+    budgets(cleaned)
+    showNotification("Budget targets saved", type = "message")
+  })
+
+  output$budget_table <- renderDT({
+    DT::datatable(
+      budgets(),
+      selection = "single",
+      editable = "cell",
+      rownames = FALSE,
+      options = list(dom = "t", pageLength = 10)
+    ) %>%
+      formatCurrency("target_amount", currency = "$", interval = 3, mark = ",")
+  })
+
+  # Reports ------------------------------------------------------------------
+  filtered_expenses <- reactive({
+    df <- expenses()
+    if (!nrow(df)) return(df)
+    range <- input$report_dates
+    df <- df %>% mutate(date = ymd(date, quiet = TRUE)) %>% filter(!is.na(date))
+    if (!is.null(range) && length(range) == 2) {
+      df <- df %>% filter(date >= range[1], date <= range[2])
+    }
+    df
+  })
+
+  category_data <- reactive({
+    category_summary(filtered_expenses(), budgets())
+  })
+
+  output$report_summary <- renderText({
+    df <- filtered_expenses()
+    if (!nrow(df)) {
+      return("No expenses recorded for the selected range yet.")
+    }
+    total <- sum(df$amount, na.rm = TRUE)
+    avg <- mean(df$amount, na.rm = TRUE)
+    sprintf("Total spent: %s\nAverage transaction: %s", dollar(total), dollar(avg))
+  })
+
+  output$spending_plot <- renderPlot({
+    df <- filtered_expenses()
+    if (!nrow(df)) return(NULL)
+    summary <- df %>%
+      group_by(category) %>%
+      summarise(spent = sum(amount, na.rm = TRUE), .groups = "drop")
+    if (!nrow(summary)) return(NULL)
+
+    ggplot(summary, aes(x = reorder(category, spent), y = spent)) +
+      geom_col(fill = "#2c7fb8") +
+      coord_flip() +
+      scale_y_continuous(labels = dollar_format()) +
+      labs(x = NULL, y = "Amount", title = "Spending by category") +
+      theme_minimal(base_size = 14)
+  })
+
+  output$category_table <- renderDT({
+    df <- category_data()
+    if (!nrow(df)) {
+      return(DT::datatable(tibble(message = "No expenses yet."), options = list(dom = "t"), rownames = FALSE))
+    }
+    DT::datatable(
+      df,
+      rownames = FALSE,
+      options = list(pageLength = 10, order = list(list(1, "desc")))
+    ) %>%
+      formatCurrency(c("spent", "target_amount", "difference"), currency = "$", interval = 3, mark = ",")
+  })
+
+  output$over_budget_table <- renderDT({
+    df <- category_data() %>% filter(target_amount > 0, spent > target_amount)
+    if (!nrow(df)) {
+      return(DT::datatable(tibble(message = "None"), options = list(dom = "t"), rownames = FALSE))
+    }
+    DT::datatable(df, rownames = FALSE, options = list(dom = "t")) %>%
+      formatCurrency(c("spent", "target_amount", "difference"), currency = "$", interval = 3, mark = ",")
+  })
+
+  output$under_budget_table <- renderDT({
+    df <- category_data() %>% filter(target_amount > 0, spent <= target_amount)
+    if (!nrow(df)) {
+      return(DT::datatable(tibble(message = "None"), options = list(dom = "t"), rownames = FALSE))
+    }
+    DT::datatable(df, rownames = FALSE, options = list(dom = "t")) %>%
+      formatCurrency(c("spent", "target_amount", "difference"), currency = "$", interval = 3, mark = ",")
+  })
+}
+
+# run ------------------------------------------------------------------------
+shinyApp(ui = ui, server = server)

--- a/r_app/launch_shiny.R
+++ b/r_app/launch_shiny.R
@@ -1,0 +1,37 @@
+args <- commandArgs(trailingOnly = TRUE)
+port <- if (length(args) >= 1) as.integer(args[[1]]) else NA_integer_
+if (is.na(port) || port <= 0) {
+  port <- 0L
+}
+
+data_dir_arg <- if (length(args) >= 2) args[[2]] else NA_character_
+if (!is.na(data_dir_arg) && nzchar(data_dir_arg)) {
+  Sys.setenv(R_SHINY_BUDGET_DATA_DIR = data_dir_arg)
+}
+
+required_packages <- c(
+  "shiny",
+  "shinythemes",
+  "DT",
+  "readr",
+  "dplyr",
+  "tidyr",
+  "lubridate",
+  "ggplot2",
+  "scales"
+)
+
+installed <- rownames(installed.packages())
+missing <- setdiff(required_packages, installed)
+if (length(missing) > 0) {
+  repos <- getOption("repos")
+  if (is.null(repos) || identical(repos, structure("@CRAN@", .Names = "CRAN"))) {
+    repos <- c(CRAN = "https://cloud.r-project.org")
+  }
+  install.packages(missing, repos = repos, quiet = TRUE)
+}
+
+options(shiny.port = port, shiny.host = "127.0.0.1")
+options(shiny.launch.browser = FALSE)
+
+shiny::runApp(appDir = ".", host = "127.0.0.1", port = port, launch.browser = FALSE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pandas>=2.0
 PySide6>=6.6
-matplotlib>=3.8


### PR DESCRIPTION
## Summary
- extend the PyInstaller helper to emit a timestamped zip archive that can be uploaded as a direct download from repository releases
- document how to share the archive and provide an Inno Setup workflow for generating a Windows installer with an optional desktop shortcut
- add an Inno Setup script that builds BudgetingToolSetup.exe and exposes the desktop icon toggle during installation

## Testing
- python -m compileall python_app installer

------
https://chatgpt.com/codex/tasks/task_e_68d40eb48dc88329ae8d67ca126e8d66